### PR TITLE
Add search options, idiomatically-typed API and more error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +961,7 @@ dependencies = [
  "dashmap",
  "derive_more",
  "env_logger",
+ "itertools",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ env_logger = "0.9.0"
 tokio = { version = "0.2.25", features = ["sync", "time"] }
 derive_more = "0.99.17"
 base32 = "0.4.0"
+itertools = "0.10.3"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,22 +1,21 @@
 // API endpoints
 
-use crate::game::adapter::GameAdapter;
-use crate::game::{
-    adapter, connect4, GameId, GameManager, GameManagerError, GameSummary, SessionId,
-};
+use crate::game::adapter::{GameAdapter, Stage};
+use crate::game::search::{GameSummary, SearchOptions, SortKey, SortOrder};
+use crate::game::{adapter, connect4, GameId, GameManager, GameType, SessionId};
 use actix_web::web::Json;
-use actix_web::{get, post, web, Error, Result};
+use actix_web::{get, post, web, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Deserialize)]
 pub struct CreateGameReq {
-    game_type: String,
+    game_type: GameType,
 }
 
 #[derive(Serialize)]
 pub struct CreateGameRes {
-    game_id: String,
+    game_id: GameId,
 }
 
 #[post("/api/create-game")]
@@ -24,26 +23,49 @@ pub(crate) async fn create_game(
     payload: web::Json<CreateGameReq>,
     gm_wrapped: web::Data<GameManager>,
 ) -> Result<Json<CreateGameRes>> {
-    let game_id = match payload.game_type.as_str() {
-        "connect_4" => gm_wrapped.create_game(|id| Box::new(connect4::Connect4Adapter::new(id))),
-        _ => {
-            return Err(Error::from(GameManagerError::NoSuchGameType(
-                payload.game_type.clone(),
-            )))
+    let game_id = match payload.game_type {
+        GameType::Connect4 => {
+            gm_wrapped.create_game(|id| Box::new(connect4::Connect4Adapter::new(id)))
         }
-    };
-    game_id.and_then(|id| {
-        Ok(Json(CreateGameRes {
-            game_id: id.to_string(),
-        }))
-    })
+    }?;
+
+    Ok(Json(CreateGameRes { game_id }))
+}
+
+#[derive(Deserialize)]
+pub struct ListGamesQuery {
+    page: Option<usize>,
+    sort_order: Option<SortOrder>,
+    sort_key: Option<SortKey>,
+    game_type: Option<GameType>,
+    players: Option<usize>,
+    stage: Option<Stage>,
 }
 
 #[get("/api/list-games")]
 pub(crate) async fn list_games(
+    query: web::Query<ListGamesQuery>,
     gm_wrapped: web::Data<GameManager>,
 ) -> Result<Json<Vec<GameSummary>>> {
-    Ok(Json(gm_wrapped.list_games()))
+    let ListGamesQuery {
+        page,
+        sort_order,
+        sort_key,
+        game_type,
+        players,
+        stage,
+    } = query.0;
+
+    let options = SearchOptions {
+        page: page.unwrap_or(1),
+        sort_order: sort_order.unwrap_or(SortOrder::Desc),
+        sort_key: sort_key.unwrap_or(SortKey::LastUpdated),
+        game_type,
+        players,
+        stage,
+    };
+
+    Ok(Json(gm_wrapped.list_games(options)?))
 }
 
 #[derive(Deserialize)]
@@ -53,37 +75,31 @@ pub struct JoinGameReq {
 
 #[derive(Serialize)]
 pub struct JoinGameRes {
-    session_id: String,
+    session_id: SessionId,
 }
 
 #[post("/api/{game_id}/join-game")]
 pub(crate) async fn join_game(
-    web::Path(game_id): web::Path<String>,
+    web::Path(game_id): web::Path<GameId>,
     payload: web::Json<JoinGameReq>,
     gm_wrapped: web::Data<GameManager>,
 ) -> Result<Json<JoinGameRes>> {
-    let game_id = GameId::from(&game_id)?;
     gm_wrapped
         .receive_join(game_id, payload.username.clone())
-        .and_then(|session_id| {
-            Ok(Json(JoinGameRes {
-                session_id: session_id.to_string(),
-            }))
-        })
+        .and_then(|session_id| Ok(Json(JoinGameRes { session_id })))
 }
 
 #[get("/api/{game_id}/get-state")]
 pub(crate) async fn get_state(
-    web::Path(game_id): web::Path<String>,
+    web::Path(game_id): web::Path<GameId>,
     gm_wrapped: web::Data<GameManager>,
 ) -> Result<Json<adapter::GenericGameState>> {
-    let game_id = GameId::from(&game_id)?;
     Ok(Json(gm_wrapped.get_state(game_id)?))
 }
 
 #[derive(Deserialize)]
 pub struct SubmitMoveReq {
-    session_id: String,
+    session_id: SessionId,
     payload: Value,
 }
 
@@ -94,15 +110,12 @@ pub struct SubmitMoveRes {
 
 #[post("/api/{game_id}/submit-move")]
 pub(crate) async fn submit_move(
-    web::Path(game_id): web::Path<String>,
+    web::Path(game_id): web::Path<GameId>,
     payload: web::Json<SubmitMoveReq>,
     gm_wrapped: web::Data<GameManager>,
 ) -> Result<Json<SubmitMoveRes>> {
-    let game_id = GameId::from(&game_id)?;
-    let session_id = SessionId::from(&payload.session_id)?;
-
     gm_wrapped
-        .receive_move(game_id, session_id, payload.payload.clone())
+        .receive_move(game_id, payload.session_id, payload.payload.clone())
         .and_then(|()| Ok(Json(SubmitMoveRes { success: true })))
 }
 
@@ -118,11 +131,10 @@ pub struct WaitForUpdateRes {
 
 #[get("/api/{game_id}/wait-for-update")]
 pub(crate) async fn wait_for_update(
-    web::Path(game_id): web::Path<String>,
+    web::Path(game_id): web::Path<GameId>,
     query: web::Query<WaitForUpdateQuery>,
     gm_wrapped: web::Data<GameManager>,
 ) -> Result<Json<WaitForUpdateRes>> {
-    let game_id = GameId::from(&game_id)?;
     Ok(Json(WaitForUpdateRes {
         clock: gm_wrapped.subscribe(game_id)?.wait(query.since).await?,
     }))

--- a/src/game/adapter.rs
+++ b/src/game/adapter.rs
@@ -1,4 +1,4 @@
-use crate::game::GameId;
+use crate::game::{GameId, GameType};
 use crate::notify::Notifier;
 use actix_web::http::StatusCode;
 use actix_web::{ResponseError, Result};
@@ -47,14 +47,11 @@ impl ResponseError for GameAdapterError {
     }
 }
 
-#[derive(Serialize, Debug, Copy, Clone, Eq, PartialEq, Display)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum Stage {
-    #[display(fmt = "waiting")]
     Waiting,
-    #[display(fmt = "in_progress")]
     InProgress,
-    #[display(fmt = "ended")]
     Ended,
 }
 
@@ -84,5 +81,5 @@ pub trait GameAdapter: Send {
     fn get_stage(&self) -> Stage;
     fn get_encoded_state(&self) -> Result<GenericGameState>;
     fn get_user_from_token(&self) -> String;
-    fn get_type(&self) -> &str;
+    fn get_type(&self) -> GameType;
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,22 +1,32 @@
 pub mod adapter;
 pub mod connect4;
+pub mod search;
 
-use std::collections::HashMap;
 use crate::game::adapter::{
     GameAdapter, GameAdapterError, GameAdapterErrorType, GenericGameMove, GenericGameState, Stage,
 };
+use crate::game::search::{GameSummary, SearchEngine, SearchOptions};
 use crate::notify::Subscription;
 use actix_web::http::StatusCode;
-use actix_web::{Error, ResponseError, Result};
+use actix_web::{ResponseError, Result};
+use chrono::{DateTime, Duration, Utc};
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use derive_more::Display;
 use rand::Rng;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt;
 use std::ops::DerefMut;
 use std::sync::Mutex;
-use chrono::{Duration, DateTime, Utc};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+pub enum GameType {
+    #[serde(rename = "connect_4")]
+    Connect4,
+}
 
 fn encode_id(bytes: &[u8]) -> String {
     base32::encode(base32::Alphabet::RFC4648 { padding: false }, bytes)
@@ -26,19 +36,25 @@ fn decode_id(data: &str) -> Option<Vec<u8>> {
     base32::decode(base32::Alphabet::RFC4648 { padding: false }, data)
 }
 
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Display)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Display)]
 #[display(fmt = "game_{}", "encode_id(_0)")]
 pub struct GameId([u8; 4]);
 
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Display)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Display)]
 #[display(fmt = "session_{}", "encode_id(_0)")]
 pub struct SessionId([u8; 16]);
 
-fn new_parse_id_error(id: &String) -> Error {
-    actix_web::Error::from(GameManagerError::InvalidId(id.clone()))
+fn new_parse_id_error<E>(id: &str) -> E
+where
+    E: de::Error,
+{
+    de::Error::custom(format!("invalid id: {}", id))
 }
 
-fn validate_id(id: &String, prefix: &str) -> Result<Vec<u8>, Error> {
+fn validate_id<E>(id: &str, prefix: &str) -> Result<Vec<u8>, E>
+where
+    E: de::Error,
+{
     if !id.starts_with(prefix) {
         return Err(new_parse_id_error(id));
     }
@@ -50,12 +66,42 @@ impl GameId {
     pub fn new() -> Self {
         GameId(rand::thread_rng().gen())
     }
+}
 
-    // Added for API to create a GameId object to input to the GameManager
-    pub fn from(id: &String) -> Result<Self> {
-        let vec = validate_id(id, "game_")?;
-        let bytes = TryInto::<[u8; 4]>::try_into(vec).or(Err(new_parse_id_error(id)))?;
-        Ok(GameId(bytes))
+impl Serialize for GameId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for GameId {
+    fn deserialize<D>(deserializer: D) -> Result<GameId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct GameIdVisitor;
+
+        impl<'de> de::Visitor<'de> for GameIdVisitor {
+            type Value = GameId;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("game id")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<GameId, E>
+            where
+                E: de::Error,
+            {
+                let vec = validate_id(v, "game_")?;
+                let bytes = TryInto::<[u8; 4]>::try_into(vec).map_err(|_| new_parse_id_error(v))?;
+                Ok(GameId(bytes))
+            }
+        }
+
+        deserializer.deserialize_string(GameIdVisitor)
     }
 }
 
@@ -63,12 +109,43 @@ impl SessionId {
     pub fn new() -> Self {
         SessionId(rand::thread_rng().gen())
     }
+}
 
-    // Added for API to create a SessionId object
-    pub fn from(id: &String) -> Result<Self> {
-        let vec = validate_id(id, "session_")?;
-        let bytes = TryInto::<[u8; 16]>::try_into(vec).or(Err(new_parse_id_error(id)))?;
-        Ok(SessionId(bytes))
+impl Serialize for SessionId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionId {
+    fn deserialize<D>(deserializer: D) -> Result<SessionId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SessionIdVisitor;
+
+        impl<'de> de::Visitor<'de> for SessionIdVisitor {
+            type Value = SessionId;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("session id")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<SessionId, E>
+            where
+                E: de::Error,
+            {
+                let vec = validate_id(v, "session_")?;
+                let bytes =
+                    TryInto::<[u8; 16]>::try_into(vec).map_err(|_| new_parse_id_error(v))?;
+                Ok(SessionId(bytes))
+            }
+        }
+
+        deserializer.deserialize_string(SessionIdVisitor)
     }
 }
 
@@ -86,10 +163,6 @@ pub enum InvalidUsernameReason {
 
 #[derive(Debug, Clone, Display)]
 pub enum GameManagerError {
-    #[display(fmt = "invalid id: {}", _0)]
-    InvalidId(String),
-    #[display(fmt = "game type {} does not exist", _0)]
-    NoSuchGameType(String),
     #[display(fmt = "no game with id {}", _0)]
     GameNotFound(GameId),
     #[display(fmt = "no session with id {}", _0)]
@@ -99,6 +172,8 @@ pub enum GameManagerError {
         username: String,
         reason: InvalidUsernameReason,
     },
+    #[display(fmt = "page must be at least one")]
+    InvalidPage,
 }
 
 impl ResponseError for GameManagerError {
@@ -125,15 +200,6 @@ pub struct Game {
     adapter: Box<dyn GameAdapter>,
     sessions: HashMap<SessionId, Session>,
     last_update: DateTime<Utc>,
-}
-
-#[derive(Serialize)]
-pub struct GameSummary {
-    pub game_id: String,
-    pub game_type: String,
-    pub players: Vec<String>,
-    pub stage: String,
-    pub last_updated: DateTime<Utc>
 }
 
 pub struct GameManager {
@@ -250,22 +316,23 @@ impl GameManager {
         panic!("State payload must be a Serde object")
     }
 
-    pub fn list_games(&self) -> Vec<GameSummary> {
-        self.games
-            .iter()
-            .map(|x| {
+    pub fn list_games(&self, options: SearchOptions) -> Result<Vec<GameSummary>> {
+        SearchEngine::apply(
+            self.games.iter().map(|x| {
                 let mut guard = x.value().lock().unwrap();
                 let game_adapter = guard.adapter.deref_mut();
-                let state = game_adapter.get_encoded_state().unwrap();
+                let GenericGameState { players, stage, .. } =
+                    game_adapter.get_encoded_state().unwrap();
                 GameSummary {
-                    game_id: x.key().to_string(),
-                    game_type: String::from(game_adapter.get_type()),
-                    players: state.players,
-                    stage: state.stage.to_string(),
-                    last_updated: guard.last_update
+                    game_id: *x.key(),
+                    game_type: game_adapter.get_type(),
+                    players,
+                    stage,
+                    last_updated: guard.last_update,
                 }
-            })
-            .collect()
+            }),
+            &options,
+        )
     }
 
     pub fn subscribe(&self, game_id: GameId) -> Result<Subscription> {

--- a/src/game/search.rs
+++ b/src/game/search.rs
@@ -1,0 +1,118 @@
+use crate::game::adapter::Stage;
+use crate::game::{GameId, GameManagerError, GameType};
+use actix_web::Result;
+use chrono::{DateTime, Utc};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+const LIST_GAME_SUMMARY_COUNT: usize = 20;
+
+#[derive(Serialize)]
+pub struct GameSummary {
+    pub game_id: GameId,
+    pub game_type: GameType,
+    pub players: Vec<String>,
+    pub stage: Stage,
+    pub last_updated: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SortOrder {
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SortKey {
+    GameType,
+    Players,
+    Stage,
+    LastUpdated,
+}
+
+pub struct SearchOptions {
+    pub page: usize,
+    pub sort_order: SortOrder,
+    pub sort_key: SortKey,
+    pub game_type: Option<GameType>,
+    pub players: Option<usize>,
+    pub stage: Option<Stage>,
+}
+
+pub struct SearchEngine;
+
+impl SearchEngine {
+    pub fn apply<I>(summaries: I, options: &SearchOptions) -> Result<Vec<GameSummary>>
+    where
+        I: Iterator<Item = GameSummary>,
+    {
+        let SearchOptions {
+            page,
+            sort_order,
+            sort_key,
+            game_type,
+            players,
+            stage,
+        } = options;
+
+        let page = *page;
+        let sort_order = *sort_order;
+        let sort_key = *sort_key;
+
+        if page == 0 {
+            return Err(actix_web::Error::from(GameManagerError::InvalidPage));
+        }
+
+        let skip = (page - 1) * LIST_GAME_SUMMARY_COUNT;
+
+        Ok(summaries
+            .sorted_by(|a, b| SearchEngine::compare_summaries(a, b, sort_key, sort_order))
+            .skip(skip)
+            .filter(|s| game_type.map_or(true, |x| s.game_type == x))
+            .filter(|s| players.map_or(true, |x| s.players.len() == x))
+            .filter(|s| stage.map_or(true, |x| s.stage == x))
+            .take(LIST_GAME_SUMMARY_COUNT)
+            .collect())
+    }
+
+    fn next_sort_key(sort_key: SortKey) -> SortKey {
+        match sort_key {
+            SortKey::GameType => SortKey::Players,
+            SortKey::Players => SortKey::Stage,
+            SortKey::Stage => SortKey::LastUpdated,
+            SortKey::LastUpdated => SortKey::GameType,
+        }
+    }
+
+    fn compare_summaries(
+        a: &GameSummary,
+        b: &GameSummary,
+        sort_key: SortKey,
+        sort_order: SortOrder,
+    ) -> Ordering {
+        let mut current_sort_key = sort_key;
+        let mut ordering = Ordering::Equal;
+
+        for _ in 0..4 {
+            ordering = match current_sort_key {
+                SortKey::GameType => Ord::cmp(&a.game_type, &b.game_type),
+                SortKey::Players => Ord::cmp(&a.players.len(), &b.players.len()),
+                SortKey::Stage => Ord::cmp(&a.stage, &b.stage),
+                SortKey::LastUpdated => Ord::cmp(&a.last_updated, &b.last_updated),
+            };
+            match ordering {
+                Ordering::Equal => current_sort_key = SearchEngine::next_sort_key(current_sort_key),
+                _ => break,
+            }
+        }
+
+        if sort_order == SortOrder::Asc {
+            ordering
+        } else {
+            ordering.reverse()
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,9 @@ mod game;
 mod notify;
 
 use actix_cors::Cors;
+use actix_web::error::InternalError;
 use actix_web::middleware::Logger;
-use actix_web::{web, App, Error, HttpServer};
+use actix_web::{web, App, HttpResponse, HttpServer};
 use std::env;
 
 const MAX_JSON_PAYLOAD_SIZE: usize = 4096;
@@ -19,7 +20,33 @@ async fn main() -> std::io::Result<()> {
     let game_manager = web::Data::new(game::GameManager::new());
     let json_config = web::JsonConfig::default()
         .limit(MAX_JSON_PAYLOAD_SIZE)
-        .error_handler(|err, _req| Error::from(err));
+        .error_handler(|err, _req| {
+            InternalError::from_response(
+                "",
+                HttpResponse::BadRequest()
+                    .content_type("text/plain")
+                    .body(err.to_string()),
+            )
+            .into()
+        });
+    let query_config = web::QueryConfig::default().error_handler(|err, _req| {
+        InternalError::from_response(
+            "",
+            HttpResponse::BadRequest()
+                .content_type("text/plain")
+                .body(err.to_string()),
+        )
+        .into()
+    });
+    let path_config = web::PathConfig::default().error_handler(|err, _req| {
+        InternalError::from_response(
+            "",
+            HttpResponse::BadRequest()
+                .content_type("text/plain")
+                .body(err.to_string()),
+        )
+        .into()
+    });
 
     HttpServer::new(move || {
         App::new()
@@ -27,6 +54,8 @@ async fn main() -> std::io::Result<()> {
             .wrap(Cors::permissive())
             .app_data(game_manager.clone())
             .app_data(json_config.clone())
+            .app_data(query_config.clone())
+            .app_data(path_config.clone())
             .service(actix_files::Files::new("/static", "./static").show_files_listing())
             .service(api::create_game)
             .service(api::list_games)

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -56,19 +56,92 @@ paths:
               $ref: '#/components/links/GameIdGetState'
             Submit move:
               $ref: '#/components/links/GameIdSubmitMove'
-        404:
-          description: Game type not found
+        400:
+          description: JSON deserialization error
           content:
             text/plain:
               schema:
-                $ref: '#/components/schemas/NoSuchGameType'
+                $ref: '#/components/schemas/JSONDeserializeError'
   /list-games:
     get:
       tags:
         - Game management
       summary: List existing games
-      description: List the ID, game type, players and stage of each existing game
+      description: List the ID, game type, players, stage and last updated time of up to 20 existing game
       operationId: listGames
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: >
+            The page of the pagination of game summaries, with the first page
+            having the first 20 results, the second having the next 20 and so
+            on
+          required: false
+        - in: query
+          name: sort_order
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
+          description: >
+            Whether the results are sorted in **asc**ending or **desc**ending
+            order, where ascending is from A to Z
+          required: false
+        - in: query
+          name: sort_key
+          schema:
+            type: string
+            enum:
+              - game_type
+              - players
+              - stage
+              - last_updated
+            default: last_updated
+          description: >
+            What the game summary list is sorted by
+            
+            - `game_type` - Sort by the type of game
+            
+            - `players` - Sort by the number of players
+            
+            - `stage` - Sort by the game stage
+            
+            - `last_updated` - Sort by the time the game was lasted updated
+            
+            Game summaries with equal values for each key are sorted by the
+            following key in the above list
+          required: false
+        - in: query
+          name: game_type
+          schema:
+            $ref: '#/components/schemas/GameType'
+          description: >
+            If this is parameter present, only games of this type are
+            searched for
+          required: false
+        - in: query
+          name: players
+          schema:
+            type: integer
+            minimum: 0
+          description: >
+            If this is parameter present, only games with this number
+            of players are searched for
+          required: false
+        - in: query
+          name: stage
+          schema:
+            $ref: '#/components/schemas/Stage'
+          description: >
+            If this is parameter present, only games in this stage are
+            searched for
+          required: false
       responses:
         200:
           description: A list of IDs, players and stages of existing games
@@ -88,6 +161,12 @@ paths:
                         game_type:
                           $ref: '#/components/schemas/GameType'
                     - $ref: '#/components/schemas/GameSummaryBase'
+        400:
+          description: Query deserialization error
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/QueryDeserializeError'
   /{game_id}/join-game:
     post:
       tags:
@@ -130,12 +209,12 @@ paths:
               $ref: '#/components/links/SessionIdSubmitMove'
         400:
           description: >
-            Game ID is invalid, username is invalid or game has already started
+            Path deserialization error, username is invalid or game has already started
           content:
             text/plain:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/InvalidId'
+                  - $ref: '#/components/schemas/PathDeserializeError'
                   - $ref: '#/components/schemas/InvalidUsername'
                   - $ref: '#/components/schemas/GameInProgress'
         404:
@@ -215,11 +294,13 @@ paths:
                         discriminator:
                           propertyName: game_type
         400:
-          description: Game ID is invalid
+          description: Path or JSON deserialization error
           content:
             text/plain:
               schema:
-                $ref: '#/components/schemas/InvalidId'
+                oneOf:
+                  - $ref: '#/components/schemas/PathDeserializeError'
+                  - $ref: '#/components/schemas/JSONDeserializeError'
         404:
           description: Game not found
           content:
@@ -272,14 +353,15 @@ paths:
                     $ref: '#/components/schemas/SessionId'
         400:
           description: >
-            Game or session ID is invalid, game is not in progress,
+            Path or JSON deserialization error, game is not in progress,
             session does not match game, move is invalid or player cannot
             currently move
           content:
             text/plain:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/InvalidId'
+                  - $ref: '#/components/schemas/PathDeserializeError'
+                  - $ref: '#/components/schemas/JSONDeserializeError'
                   - $ref: '#/components/schemas/GameWaiting'
                   - $ref: '#/components/schemas/GameEnded'
                   - $ref: '#/components/schemas/InvalidMove'
@@ -329,6 +411,15 @@ paths:
                   clock:
                     type: integer
                     description: The current clock value at the server
+        400:
+          description: >
+            Path or query deserialization error
+          content:
+            text/plain:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/PathDeserializeError'
+                  - $ref: '#/components/schemas/QueryDeserializeError'
 components:
   schemas:
     GameTypeBase:
@@ -371,21 +462,23 @@ components:
             - Player 1
             - Player 2
         stage:
-          type: string
-          enum:
-            - waiting
-            - in_progress
-            - ended
-          description: >
-            Whether the game is waiting for players, in progress or
-            over
-          example: in_progress
+          $ref: '#/components/schemas/Stage'
         last_updated:
           type: string
           format: date-time
           description: >
             The time of the most recent update to the game's state
           example: 2022-02-22T12:33:30+0000
+    Stage:
+      type: string
+      enum:
+        - waiting
+        - in_progress
+        - ended
+      description: >
+        Whether a game is waiting for players, in progress or
+        over
+      example: in_progress
     Connect4Request:
       type: object
       required:
@@ -435,14 +528,19 @@ components:
           minimum: 1
           maximum: 7
       description: Payload for a connect 4 game move
-    NoSuchGameType:
+    JSONDeserializeError:
       type: string
-      pattern: '^game type .+ does not exist$'
-      example: 'game type connect_minus_4 does not exist'
-    InvalidId:
+      pattern: '^Json deserialize error:'
+    PathDeserializeError:
       type: string
-      pattern: '^invalid id:'
-      example: 'invalid id: game_NF6G5NI'
+      pattern: '^Path deserialize error:'
+    QueryDeserializeError:
+      type: string
+      pattern: '^Query deserialize error:'
+    PayloadSizeError:
+      type: string
+      pattern: '^Json payload size is bigger than allowed$'
+      example: 'Json payload size is bigger than allowed'
     GameNotFound:
       type: string
       pattern: '^game game_[A-Z0-9]+ does not exist$'


### PR DESCRIPTION
- Add search pagination, sorting and filtering
- Fix game and session ID serialisation
- Fix JSON errors sometimes not being sent to the client
- Add error messages for query and path errors
- Make API more idiomatic by adding types to request and response structs (resulting in less error handling and better error messages)
- Send specific types rather than strings around the program for improved safety
- Validate connect_4 request payload game type field
- Update OpenAPI spec with new listing query parameters and new error messages
- Remove now-unnecessary display traits

A drawback of this change is that we have a lot of serialisation and deserialisation code for IDs — we may want to move the IDs to their own file.